### PR TITLE
Delivery 서비스 리팩토링

### DIFF
--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/notification/NotificationService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/notification/NotificationService.java
@@ -1,0 +1,8 @@
+package com.chill_guys.delivery_service.application.notification;
+
+import com.chill_guys.delivery_service.domain.model.Delivery;
+
+public interface NotificationService {
+
+    void sendMessage(String type, Delivery delivery, String slackId, String recipientAddress);
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/scheduler/DeliveryAssignmentScheduler.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/scheduler/DeliveryAssignmentScheduler.java
@@ -1,10 +1,14 @@
-package com.chill_guys.delivery_service.application.service;
+package com.chill_guys.delivery_service.application.scheduler;
 
+import com.chill_guys.delivery_service.application.service.DeliveryRouteService;
+import com.chill_guys.delivery_service.application.service.DeliveryService;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/CompanyService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/CompanyService.java
@@ -1,0 +1,7 @@
+package com.chill_guys.delivery_service.application.service;
+
+import java.util.UUID;
+
+public interface CompanyService {
+    UUID getHubIdByCompanyId(UUID companyId);
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryManagerService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryManagerService.java
@@ -1,0 +1,12 @@
+package com.chill_guys.delivery_service.application.service;
+
+import com.chill_guys.delivery_service.application.dto.response.DeliveryManagerInfoDto;
+
+import java.util.UUID;
+
+public interface DeliveryManagerService {
+
+    DeliveryManagerInfoDto assignDeliveryManager(UUID startHubId,
+                                                 UUID endHubId,
+                                                 String type);
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryRouteService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryRouteService.java
@@ -1,138 +1,27 @@
 package com.chill_guys.delivery_service.application.service;
 
 import com.chill_guys.delivery_service.application.dto.request.DeliveryRouteUpdateRequestDto;
-import com.chill_guys.delivery_service.application.dto.response.DeliveryManagerInfoDto;
 import com.chill_guys.delivery_service.application.dto.response.DeliveryRouteResponseDto;
-import com.chill_guys.delivery_service.application.dto.response.HubRouteListResponseDto;
-import com.chill_guys.delivery_service.application.mapper.DeliveryRouteMapper;
 import com.chill_guys.delivery_service.domain.model.Delivery;
-import com.chill_guys.delivery_service.domain.model.DeliveryRoute;
 import com.chill_guys.delivery_service.domain.model.DeliveryRouteStatus;
-import com.chill_guys.delivery_service.domain.repository.DeliveryRouteRepository;
-import com.chill_guys.delivery_service.exception.CustomException;
-import com.chill_guys.delivery_service.exception.DeliveryErrorCode;
-import com.chill_guys.delivery_service.infrastructure.client.DeliveryManagerClient;
-import com.chill_guys.delivery_service.infrastructure.client.HubRouteClient;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+public interface DeliveryRouteService {
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class DeliveryRouteService {
+    void createDeliveryRoutes(Delivery delivery);
 
-    private final DeliveryRouteRepository deliveryRouteRepository;
-    private final HubRouteClient hubRouteClient;
-    private final DeliveryManagerClient deliveryManagerClient;
+    List<DeliveryRouteResponseDto> getDeliveryRoutesList(UUID deliveryId);
 
-    @Transactional
-    public void createDeliveryRoutes(Delivery delivery) {
+    DeliveryRouteResponseDto getDeliveryRoute(UUID deliveryId, UUID routesId);
 
-        // 1. 출발+도착 허브 보고 허브간 이동경로 조회
-        List<HubRouteListResponseDto> hubRouteList = hubRouteClient.getHubRouteList(delivery.getDepartureHubId(), delivery.getDestinationHubId());
+    void updateDeliveryRoute(UUID deliveryId, UUID routesId, DeliveryRouteUpdateRequestDto deliveryRouteUpdateRequestDto);
 
-        // 2. 조회 된 허브간 이동 경로에서 시작허브, 도착허브 예상거리, 예상 소요시간 조회
-        Integer sequence = 1;
+    void deleteDeliveryRoute(UUID deliveryId, UUID routesId, String userId);
 
-        for(HubRouteListResponseDto hubRoute : hubRouteList){
-            UUID startHubId = hubRoute.getStartHubId();
-            UUID endHubId = hubRoute.getEndHubId();
-            Double estimatedDistance = hubRoute.getDeliveryDistance();
-            Integer estimatedTime = hubRoute.getDeliveryTime();
+    void assignPendingDeliveries();
 
-            // TODO: 실제 걸린시간 어딘가에서 가져오기..
-            Double actualDistance = 212.4677;
-            Integer actualTime = 135;
+    void changeDeliveryStatus(UUID deliveryId, UUID routesId, DeliveryRouteStatus status);
 
-            DeliveryRoute deliveryRoute = DeliveryRouteMapper.toEntity(
-                    delivery.getId(),
-                    sequence++,
-                    startHubId,
-                    endHubId,
-                    estimatedDistance,
-                    estimatedTime,
-                    actualDistance,
-                    actualTime);
-
-            deliveryRouteRepository.save(deliveryRoute);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public List<DeliveryRouteResponseDto> getDeliveryRoutesList(UUID deliveryId) {
-        List<DeliveryRoute> deliveryRouteList = deliveryRouteRepository.findByDeliveryIdAndDeletedAtIsNull(deliveryId);
-
-        List<DeliveryRouteResponseDto> deliveryRouteResponseDtoList = new ArrayList<>();
-
-        for(DeliveryRoute deliveryRoute : deliveryRouteList){
-            deliveryRouteResponseDtoList.add(DeliveryRouteMapper.toDto(deliveryRoute));
-        }
-
-        return deliveryRouteResponseDtoList;
-    }
-
-    @Transactional(readOnly = true)
-    public DeliveryRouteResponseDto getDeliveryRoute(UUID deliveryId, UUID routesId) {
-        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
-
-        return DeliveryRouteMapper.toDto(deliveryRoute);
-    }
-
-    @Transactional
-    public void updateDeliveryRoute(UUID deliveryId, UUID routesId, DeliveryRouteUpdateRequestDto deliveryRouteUpdateRequestDto) {
-        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
-
-        if(deliveryRoute.isInfoChangeable()) {
-            deliveryRoute.updateOf(deliveryRouteUpdateRequestDto);
-
-        } else throw new CustomException(DeliveryErrorCode.DELIVERY_IN_START);
-
-        deliveryRouteRepository.save(deliveryRoute);
-    }
-
-
-    @Transactional
-    public void deleteDeliveryRoute(UUID deliveryId, UUID routesId, String userId) {
-        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
-        Long id = Long.parseLong(userId);
-        deliveryRoute.deletedOf(id);
-    }
-
-
-    @Transactional
-    public void assignPendingDeliveries() {
-        List<DeliveryRoute> pendingDeliveryies = deliveryRouteRepository.findByStatusAndDeletedAtIsNull(DeliveryRouteStatus.PENDING);
-
-        if(pendingDeliveryies.isEmpty()) {
-            return;
-        }
-
-        for(DeliveryRoute deliveryRoute : pendingDeliveryies) {
-            UUID startHubId = deliveryRoute.getStartHudId();
-            UUID endHubId = deliveryRoute.getEndHudId();
-            DeliveryManagerInfoDto dto = deliveryManagerClient.assignDeliveryManager(startHubId, endHubId, "COMPANY");
-            deliveryRoute.assignHubDeliveryManager(dto.getId());
-
-            log.info("HubDeliveryManager Assigned");
-        }
-    }
-
-    @Transactional
-    public void changeDeliveryStatus(UUID deliveryId, UUID routesId, DeliveryRouteStatus status) {
-        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
-        deliveryRoute.changeDeliveryStatus(status);
-    }
-
-
-    private DeliveryRoute findDeliveryRouteById(UUID routeId, UUID deliveryId) {
-        return deliveryRouteRepository.findByIdAndDeliveryIdAndDeletedAtIsNull(routeId, deliveryId)
-                .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_ROUTE_NOT_FOUND));
-    }
 }

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryRouteService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryRouteService.java
@@ -110,15 +110,17 @@ public class DeliveryRouteService {
     public void assignPendingDeliveries() {
         List<DeliveryRoute> pendingDeliveryies = deliveryRouteRepository.findByStatusAndDeletedAtIsNull(DeliveryRouteStatus.PENDING);
 
-        if(!pendingDeliveryies.isEmpty()) {
-            for(DeliveryRoute deliveryRoute : pendingDeliveryies) {
-                UUID startHubId = deliveryRoute.getStartHudId();
-                UUID endHubId = deliveryRoute.getEndHudId();
-                DeliveryManagerInfoDto dto = deliveryManagerClient.assignDeliveryManager(startHubId, endHubId, "COMPANY");
-                deliveryRoute.assignHubDeliveryManager(dto.getId());
+        if(pendingDeliveryies.isEmpty()) {
+            return;
+        }
 
-                log.info("HubDeliveryManager Assigned");
-            }
+        for(DeliveryRoute deliveryRoute : pendingDeliveryies) {
+            UUID startHubId = deliveryRoute.getStartHudId();
+            UUID endHubId = deliveryRoute.getEndHudId();
+            DeliveryManagerInfoDto dto = deliveryManagerClient.assignDeliveryManager(startHubId, endHubId, "COMPANY");
+            deliveryRoute.assignHubDeliveryManager(dto.getId());
+
+            log.info("HubDeliveryManager Assigned");
         }
     }
 

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryService.java
@@ -79,8 +79,6 @@ public class DeliveryService {
         if(delivery.isInfoChangeable()) {
             delivery.updateOf(deliveryUpdateRequestDto);
         } else throw new CustomException(DeliveryErrorCode.DELIVERY_IN_START);
-
-        deliveryRepository.save(delivery);
     }
 
     @Transactional

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryService.java
@@ -90,26 +90,29 @@ public class DeliveryService {
         delivery.deletedOf(id);
     }
 
+
     @Transactional
     public void assignPendingDeliveries() {
         List<Delivery> pendingDeliveryies = deliveryRepository.findByDeliveryStatusAndDeletedAtIsNull(DeliveryStatus.PENDING);
 
-        if(!pendingDeliveryies.isEmpty()) {
+        if(pendingDeliveryies.isEmpty()) {
+            return;
+        }
 
-            for(Delivery delivery : pendingDeliveryies) {
-                UUID departureHubId = delivery.getDepartureHubId();
-                UUID destinationHubId = delivery.getDestinationHubId();
-                String type = "HUB";
-                DeliveryManagerInfoDto dto = deliveryManagerClient.assignDeliveryManager(departureHubId, destinationHubId, type);
-                delivery.assignDeliveryManager(dto.getId());
+        for(Delivery delivery : pendingDeliveryies) {
+            UUID departureHubId = delivery.getDepartureHubId();
+            UUID destinationHubId = delivery.getDestinationHubId();
+            String type = "HUB";
+            DeliveryManagerInfoDto dto = deliveryManagerClient.assignDeliveryManager(departureHubId, destinationHubId, type);
+            delivery.assignDeliveryManager(dto.getId());
 
-                log.info("DeliveryManager Assigned");
+            log.info("DeliveryManager Assigned");
 
-                // 배송정보를 kafka로 전송
-                producerService.sendInfo(type, DeliveryInfoMapper.toDto(delivery, dto.getSlackId(), delivery.getRecipientCompany().getAddress()));
-            }
+            // 배송정보를 kafka로 전송
+            producerService.sendInfo(type, DeliveryInfoMapper.toDto(delivery, dto.getSlackId(), delivery.getRecipientCompany().getAddress()));
         }
     }
+
 
     @Transactional
     public void changeDeliveryStatus(UUID deliveryId, DeliveryStatus deliveryStatus) {

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/DeliveryService.java
@@ -1,127 +1,27 @@
 package com.chill_guys.delivery_service.application.service;
 
-import com.chill_guys.delivery_service.application.dto.request.OrderDeliveryRequestDto;
 import com.chill_guys.delivery_service.application.dto.request.DeliveryUpdateRequestDto;
-import com.chill_guys.delivery_service.application.dto.response.DeliveryManagerInfoDto;
+import com.chill_guys.delivery_service.application.dto.request.OrderDeliveryRequestDto;
 import com.chill_guys.delivery_service.application.dto.response.DeliveryResponseDto;
-import com.chill_guys.delivery_service.infrastructure.messaging.dto.DeliveryInfoMapper;
-import com.chill_guys.delivery_service.application.mapper.DeliveryMapper;
-import com.chill_guys.delivery_service.domain.model.Delivery;
 import com.chill_guys.delivery_service.domain.model.DeliveryStatus;
-import com.chill_guys.delivery_service.domain.repository.DeliveryRepository;
-import com.chill_guys.delivery_service.exception.CustomException;
-import com.chill_guys.delivery_service.exception.DeliveryErrorCode;
-import com.chill_guys.delivery_service.infrastructure.client.CompanyClient;
-import com.chill_guys.delivery_service.infrastructure.client.DeliveryManagerClient;
-import com.chill_guys.delivery_service.infrastructure.client.ProductClient;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class DeliveryService {
+public interface DeliveryService {
 
-    private final DeliveryRepository deliveryRepository;
-    private final DeliveryRouteService deliveryRouteService;
+    UUID createDelivery(OrderDeliveryRequestDto orderDeliveryRequestDto);
 
-    private final DeliveryManagerClient deliveryManagerClient;
-    private final CompanyClient companyClient;
-    private final ProductClient productClient;
+    List<DeliveryResponseDto> getDeliveryList();
 
-    private final ProducerService producerService;
+    DeliveryResponseDto getDelivery(UUID deliveryId);
 
-    @Transactional
-    public UUID createDelivery(OrderDeliveryRequestDto orderDeliveryRequestDto) {
-        // 1. 상품을 보고 출발 허브 결정
-        UUID productId = orderDeliveryRequestDto.getProductId();
-        UUID departureHubId = productClient.getHubIdByProductId(productId);
+    void updateDelivery(UUID deliveryId, DeliveryUpdateRequestDto deliveryUpdateRequestDto);
 
-        // 2. 수령 업체 보고 도착 허브 결정
-        UUID destinationHubId = companyClient.getHubIdByCompanyId(orderDeliveryRequestDto.getRequestCompanyId());
+    void deleteDelivery(UUID deliveryId, String userId);
 
-        // 3. 배송 저장
-        Delivery delivery = DeliveryMapper.toEntity(orderDeliveryRequestDto, departureHubId, destinationHubId);
-        deliveryRepository.save(delivery);
+    void assignPendingDeliveries();
 
-        deliveryRouteService.createDeliveryRoutes(delivery);
+    void changeDeliveryStatus(UUID deliveryId, DeliveryStatus deliveryStatus);
 
-        return delivery.getId();
-    }
-
-    @Transactional(readOnly = true)
-    public List<DeliveryResponseDto> getDeliveryList() {
-        List<Delivery> deliveryList = deliveryRepository.findByAndDeletedAtIsNull();
-
-        List<DeliveryResponseDto> deliveryResponseDtoList = new ArrayList<>();
-        for(Delivery delivery : deliveryList) {
-            deliveryResponseDtoList.add(DeliveryMapper.toDto(delivery));
-        }
-        return deliveryResponseDtoList;
-    }
-
-    @Transactional(readOnly = true)
-    public DeliveryResponseDto getDelivery(UUID deliveryId) {
-        Delivery delivery = findDeliveryById(deliveryId);
-        return DeliveryMapper.toDto(delivery);
-    }
-
-    @Transactional
-    public void updateDelivery(UUID deliveryId, DeliveryUpdateRequestDto deliveryUpdateRequestDto) {
-        Delivery delivery = findDeliveryById(deliveryId);
-
-        if(delivery.isInfoChangeable()) {
-            delivery.updateOf(deliveryUpdateRequestDto);
-        } else throw new CustomException(DeliveryErrorCode.DELIVERY_IN_START);
-    }
-
-    @Transactional
-    public void deleteDelivery(UUID deliveryId, String userId) {
-        Delivery delivery = findDeliveryById(deliveryId);
-        Long id = Long.parseLong(userId);
-        delivery.deletedOf(id);
-    }
-
-
-    @Transactional
-    public void assignPendingDeliveries() {
-        List<Delivery> pendingDeliveryies = deliveryRepository.findByDeliveryStatusAndDeletedAtIsNull(DeliveryStatus.PENDING);
-
-        if(pendingDeliveryies.isEmpty()) {
-            return;
-        }
-
-        for(Delivery delivery : pendingDeliveryies) {
-            UUID departureHubId = delivery.getDepartureHubId();
-            UUID destinationHubId = delivery.getDestinationHubId();
-            String type = "HUB";
-            DeliveryManagerInfoDto dto = deliveryManagerClient.assignDeliveryManager(departureHubId, destinationHubId, type);
-            delivery.assignDeliveryManager(dto.getId());
-
-            log.info("DeliveryManager Assigned");
-
-            // 배송정보를 kafka로 전송
-            producerService.sendInfo(type, DeliveryInfoMapper.toDto(delivery, dto.getSlackId(), delivery.getRecipientCompany().getAddress()));
-        }
-    }
-
-
-    @Transactional
-    public void changeDeliveryStatus(UUID deliveryId, DeliveryStatus deliveryStatus) {
-        Delivery delivery = findDeliveryById(deliveryId);
-
-        delivery.changeDeliveryStatus(deliveryStatus);
-    }
-
-
-    private Delivery findDeliveryById(UUID deliveryId) {
-        return deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-                .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
-    }
 }

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/HubRouteService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/HubRouteService.java
@@ -1,0 +1,11 @@
+package com.chill_guys.delivery_service.application.service;
+
+import com.chill_guys.delivery_service.application.dto.response.HubRouteListResponseDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface HubRouteService {
+
+    List<HubRouteListResponseDto> getHubRouteList(UUID startHubId, UUID endHubId);
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/ProductService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/ProductService.java
@@ -1,0 +1,8 @@
+package com.chill_guys.delivery_service.application.service;
+
+import java.util.UUID;
+
+public interface ProductService {
+
+    UUID getHubIdByProductId(UUID productId);
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/CompanyServiceImpl.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/CompanyServiceImpl.java
@@ -1,0 +1,20 @@
+package com.chill_guys.delivery_service.application.service.impl;
+
+import com.chill_guys.delivery_service.application.service.CompanyService;
+import com.chill_guys.delivery_service.infrastructure.client.CompanyClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyServiceImpl implements CompanyService {
+
+    private final CompanyClient companyClient;
+
+    @Override
+    public UUID getHubIdByCompanyId(UUID companyId) {
+        return companyClient.getHubIdByCompanyId(companyId);
+    }
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/DeliveryManagerServiceImpl.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/DeliveryManagerServiceImpl.java
@@ -1,0 +1,21 @@
+package com.chill_guys.delivery_service.application.service.impl;
+
+import com.chill_guys.delivery_service.application.dto.response.DeliveryManagerInfoDto;
+import com.chill_guys.delivery_service.application.service.DeliveryManagerService;
+import com.chill_guys.delivery_service.infrastructure.client.DeliveryManagerClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryManagerServiceImpl implements DeliveryManagerService {
+
+    private final DeliveryManagerClient deliveryManagerClient;
+
+    @Override
+    public DeliveryManagerInfoDto assignDeliveryManager(UUID startHubId, UUID endHubId, String type) {
+        return deliveryManagerClient.assignDeliveryManager(startHubId, endHubId, type);
+    }
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/DeliveryRouteServiceImpl.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/DeliveryRouteServiceImpl.java
@@ -1,0 +1,146 @@
+package com.chill_guys.delivery_service.application.service.impl;
+
+import com.chill_guys.delivery_service.application.dto.request.DeliveryRouteUpdateRequestDto;
+import com.chill_guys.delivery_service.application.dto.response.DeliveryManagerInfoDto;
+import com.chill_guys.delivery_service.application.dto.response.DeliveryRouteResponseDto;
+import com.chill_guys.delivery_service.application.dto.response.HubRouteListResponseDto;
+import com.chill_guys.delivery_service.application.mapper.DeliveryRouteMapper;
+import com.chill_guys.delivery_service.application.service.DeliveryManagerService;
+import com.chill_guys.delivery_service.application.service.DeliveryRouteService;
+import com.chill_guys.delivery_service.application.service.HubRouteService;
+import com.chill_guys.delivery_service.domain.model.Delivery;
+import com.chill_guys.delivery_service.domain.model.DeliveryRoute;
+import com.chill_guys.delivery_service.domain.model.DeliveryRouteStatus;
+import com.chill_guys.delivery_service.domain.repository.DeliveryRouteRepository;
+import com.chill_guys.delivery_service.exception.CustomException;
+import com.chill_guys.delivery_service.exception.DeliveryErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryRouteServiceImpl implements DeliveryRouteService {
+
+    private final DeliveryRouteRepository deliveryRouteRepository;
+    private final HubRouteService hubRouteService;
+    private final DeliveryManagerService deliveryManagerService;
+
+    @Override
+    @Transactional
+    public void createDeliveryRoutes(Delivery delivery) {
+
+        // 1. 출발+도착 허브 보고 허브간 이동경로 조회
+        List<HubRouteListResponseDto> hubRouteList = hubRouteService.getHubRouteList(delivery.getDepartureHubId(), delivery.getDestinationHubId());
+
+        // 2. 조회 된 허브간 이동 경로에서 시작허브, 도착허브 예상거리, 예상 소요시간 조회
+        Integer sequence = 1;
+
+        for(HubRouteListResponseDto hubRoute : hubRouteList){
+            UUID startHubId = hubRoute.getStartHubId();
+            UUID endHubId = hubRoute.getEndHubId();
+            Double estimatedDistance = hubRoute.getDeliveryDistance();
+            Integer estimatedTime = hubRoute.getDeliveryTime();
+
+            // TODO: 실제 걸린시간 어딘가에서 가져오기..
+            Double actualDistance = 212.4677;
+            Integer actualTime = 135;
+
+            DeliveryRoute deliveryRoute = DeliveryRouteMapper.toEntity(
+                    delivery.getId(),
+                    sequence++,
+                    startHubId,
+                    endHubId,
+                    estimatedDistance,
+                    estimatedTime,
+                    actualDistance,
+                    actualTime);
+
+            deliveryRouteRepository.save(deliveryRoute);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DeliveryRouteResponseDto> getDeliveryRoutesList(UUID deliveryId) {
+        List<DeliveryRoute> deliveryRouteList = deliveryRouteRepository.findByDeliveryIdAndDeletedAtIsNull(deliveryId);
+
+        List<DeliveryRouteResponseDto> deliveryRouteResponseDtoList = new ArrayList<>();
+
+        for(DeliveryRoute deliveryRoute : deliveryRouteList){
+            deliveryRouteResponseDtoList.add(DeliveryRouteMapper.toDto(deliveryRoute));
+        }
+
+        return deliveryRouteResponseDtoList;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DeliveryRouteResponseDto getDeliveryRoute(UUID deliveryId, UUID routesId) {
+        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
+
+        return DeliveryRouteMapper.toDto(deliveryRoute);
+    }
+
+    @Override
+    @Transactional
+    public void updateDeliveryRoute(UUID deliveryId, UUID routesId, DeliveryRouteUpdateRequestDto deliveryRouteUpdateRequestDto) {
+        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
+
+        if(deliveryRoute.isInfoChangeable()) {
+            deliveryRoute.updateOf(deliveryRouteUpdateRequestDto);
+
+        } else throw new CustomException(DeliveryErrorCode.DELIVERY_IN_START);
+
+        deliveryRouteRepository.save(deliveryRoute);
+    }
+
+
+    @Override
+    @Transactional
+    public void deleteDeliveryRoute(UUID deliveryId, UUID routesId, String userId) {
+        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
+        Long id = Long.parseLong(userId);
+        deliveryRoute.deletedOf(id);
+    }
+
+
+    @Override
+    @Transactional
+    public void assignPendingDeliveries() {
+        List<DeliveryRoute> pendingDeliveries = deliveryRouteRepository.findByStatusAndDeletedAtIsNull(DeliveryRouteStatus.PENDING);
+
+        if(pendingDeliveries.isEmpty()) {
+            return;
+        }
+
+        for(DeliveryRoute deliveryRoute : pendingDeliveries) {
+            UUID startHubId = deliveryRoute.getStartHudId();
+            UUID endHubId = deliveryRoute.getEndHudId();
+            DeliveryManagerInfoDto dto = deliveryManagerService.assignDeliveryManager(startHubId, endHubId, "COMPANY");
+            deliveryRoute.assignHubDeliveryManager(dto.getId());
+
+            log.info("HubDeliveryManager Assigned");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void changeDeliveryStatus(UUID deliveryId, UUID routesId, DeliveryRouteStatus status) {
+        DeliveryRoute deliveryRoute = findDeliveryRouteById(routesId, deliveryId);
+        deliveryRoute.changeDeliveryStatus(status);
+    }
+
+
+    private DeliveryRoute findDeliveryRouteById(UUID routeId, UUID deliveryId) {
+        return deliveryRouteRepository.findByIdAndDeliveryIdAndDeletedAtIsNull(routeId, deliveryId)
+                .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_ROUTE_NOT_FOUND));
+    }
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/DeliveryServiceImpl.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/DeliveryServiceImpl.java
@@ -1,0 +1,133 @@
+package com.chill_guys.delivery_service.application.service.impl;
+
+import com.chill_guys.delivery_service.application.dto.request.OrderDeliveryRequestDto;
+import com.chill_guys.delivery_service.application.dto.request.DeliveryUpdateRequestDto;
+import com.chill_guys.delivery_service.application.dto.response.DeliveryManagerInfoDto;
+import com.chill_guys.delivery_service.application.dto.response.DeliveryResponseDto;
+import com.chill_guys.delivery_service.application.notification.NotificationService;
+import com.chill_guys.delivery_service.application.service.*;
+import com.chill_guys.delivery_service.application.mapper.DeliveryMapper;
+import com.chill_guys.delivery_service.domain.model.Delivery;
+import com.chill_guys.delivery_service.domain.model.DeliveryStatus;
+import com.chill_guys.delivery_service.domain.repository.DeliveryRepository;
+import com.chill_guys.delivery_service.exception.CustomException;
+import com.chill_guys.delivery_service.exception.DeliveryErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryServiceImpl implements DeliveryService {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryRouteServiceImpl deliveryRouteServiceImpl;
+
+    private final DeliveryManagerService deliveryManagerService;
+    private final CompanyService companyService;
+    private final ProductService productService;
+
+    private final NotificationService notificationService;
+
+    @Override
+    @Transactional
+    public UUID createDelivery(OrderDeliveryRequestDto orderDeliveryRequestDto) {
+        // 1. 상품을 보고 출발 허브 결정
+        UUID productId = orderDeliveryRequestDto.getProductId();
+        UUID departureHubId = productService.getHubIdByProductId(productId);
+
+        // 2. 수령 업체 보고 도착 허브 결정
+        UUID destinationHubId = companyService.getHubIdByCompanyId(orderDeliveryRequestDto.getRequestCompanyId());
+
+        // 3. 배송 저장
+        Delivery delivery = DeliveryMapper.toEntity(orderDeliveryRequestDto, departureHubId, destinationHubId);
+        deliveryRepository.save(delivery);
+
+        deliveryRouteServiceImpl.createDeliveryRoutes(delivery);
+
+        return delivery.getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DeliveryResponseDto> getDeliveryList() {
+        List<Delivery> deliveryList = deliveryRepository.findByAndDeletedAtIsNull();
+
+        List<DeliveryResponseDto> deliveryResponseDtoList = new ArrayList<>();
+        for(Delivery delivery : deliveryList) {
+            deliveryResponseDtoList.add(DeliveryMapper.toDto(delivery));
+        }
+        return deliveryResponseDtoList;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DeliveryResponseDto getDelivery(UUID deliveryId) {
+        Delivery delivery = findDeliveryById(deliveryId);
+        return DeliveryMapper.toDto(delivery);
+    }
+
+    @Override
+    @Transactional
+    public void updateDelivery(UUID deliveryId, DeliveryUpdateRequestDto deliveryUpdateRequestDto) {
+        Delivery delivery = findDeliveryById(deliveryId);
+
+        if(delivery.isInfoChangeable()) {
+            delivery.updateOf(deliveryUpdateRequestDto);
+        } else throw new CustomException(DeliveryErrorCode.DELIVERY_IN_START);
+    }
+
+    @Override
+    @Transactional
+    public void deleteDelivery(UUID deliveryId, String userId) {
+        Delivery delivery = findDeliveryById(deliveryId);
+        Long id = Long.parseLong(userId);
+        delivery.deletedOf(id);
+    }
+
+
+    @Override
+    @Transactional
+    public void assignPendingDeliveries() {
+        List<Delivery> pendingDeliveryies = deliveryRepository.findByDeliveryStatusAndDeletedAtIsNull(DeliveryStatus.PENDING);
+
+        if(pendingDeliveryies.isEmpty()) {
+            return;
+        }
+
+        for(Delivery delivery : pendingDeliveryies) {
+            UUID departureHubId = delivery.getDepartureHubId();
+            UUID destinationHubId = delivery.getDestinationHubId();
+            String type = "HUB";
+            DeliveryManagerInfoDto dto = deliveryManagerService.assignDeliveryManager(departureHubId, destinationHubId, type);
+            delivery.assignDeliveryManager(dto.getId());
+
+            log.info("DeliveryManager Assigned");
+
+            // 배송정보를 kafka로 전송
+            notificationService.sendMessage(type, delivery, dto.getSlackId(), delivery.getRecipientCompany().getAddress());
+
+        }
+    }
+
+
+    @Override
+    @Transactional
+    public void changeDeliveryStatus(UUID deliveryId, DeliveryStatus deliveryStatus) {
+        Delivery delivery = findDeliveryById(deliveryId);
+
+        delivery.changeDeliveryStatus(deliveryStatus);
+    }
+
+
+    private Delivery findDeliveryById(UUID deliveryId) {
+        return deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
+                .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+    }
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/HubRouteServiceImpl.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/HubRouteServiceImpl.java
@@ -1,0 +1,22 @@
+package com.chill_guys.delivery_service.application.service.impl;
+
+import com.chill_guys.delivery_service.application.dto.response.HubRouteListResponseDto;
+import com.chill_guys.delivery_service.application.service.HubRouteService;
+import com.chill_guys.delivery_service.infrastructure.client.HubRouteClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class HubRouteServiceImpl implements HubRouteService {
+
+    private final HubRouteClient hubRouteClient;
+
+    @Override
+    public List<HubRouteListResponseDto> getHubRouteList(UUID startHubId, UUID endHubId) {
+        return hubRouteClient.getHubRouteList(startHubId, endHubId);
+    }
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/ProductServiceImpl.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/application/service/impl/ProductServiceImpl.java
@@ -1,0 +1,20 @@
+package com.chill_guys.delivery_service.application.service.impl;
+
+import com.chill_guys.delivery_service.application.service.ProductService;
+import com.chill_guys.delivery_service.infrastructure.client.ProductClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final ProductClient productClient;
+
+    @Override
+    public UUID getHubIdByProductId(UUID productId) {
+        return productClient.getHubIdByProductId(productId);
+    }
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/infrastructure/messaging/service/ProducerService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/infrastructure/messaging/service/ProducerService.java
@@ -1,4 +1,4 @@
-package com.chill_guys.delivery_service.application.service;
+package com.chill_guys.delivery_service.infrastructure.messaging.service;
 
 import com.chill_guys.delivery_service.infrastructure.messaging.dto.DeliveryInfoDto;
 import lombok.RequiredArgsConstructor;

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/infrastructure/messaging/service/SlackNotificationService.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/infrastructure/messaging/service/SlackNotificationService.java
@@ -1,0 +1,21 @@
+package com.chill_guys.delivery_service.infrastructure.messaging.service;
+
+import com.chill_guys.delivery_service.application.notification.NotificationService;
+import com.chill_guys.delivery_service.domain.model.Delivery;
+import com.chill_guys.delivery_service.infrastructure.messaging.dto.DeliveryInfoDto;
+import com.chill_guys.delivery_service.infrastructure.messaging.dto.DeliveryInfoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SlackNotificationService implements NotificationService {
+
+    private final ProducerService producerService;
+
+    @Override
+    public void sendMessage(String type, Delivery delivery, String slackId, String recipientAddress) {
+        DeliveryInfoDto dto = DeliveryInfoMapper.toDto(delivery, slackId, recipientAddress);
+        producerService.sendInfo(type, dto);
+    }
+}

--- a/delivery-service/src/main/java/com/chill_guys/delivery_service/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/chill_guys/delivery_service/presentation/DeliveryController.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/deliveries")
 @RequiredArgsConstructor
-public class DelieveryController {
+public class DeliveryController {
 
     private final DeliveryService deliveryService;
 

--- a/delivery-service/src/test/java/com/chill_guys/delivery_service/DeliveryServiceImplApplicationTests.java
+++ b/delivery-service/src/test/java/com/chill_guys/delivery_service/DeliveryServiceImplApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class DeliveryServiceApplicationTests {
+class DeliveryServiceImplApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
- 배송 담당자 배정 로직에 얼리리턴 적용
- JPA 더티체킹 기능으로 변경 사항 자동 감지
- 서비스 간 통신 구조를 OCP 원칙에 따라 개선
  - Company, DeliveryManager, HubRoute, Product 서비스 연동을 추상화된 인터페이스로 분리
  - FeignClient 직접 의존성을 서비스 구현체로 구현
  - DeliveryService가 직접 의존하지 않도록 개선
- 서비스 계층을 인터페이스와 구현체로 분리
- 슬랙 알림 전송 로직에 OCP 원칙 적용
  - 알림 전송 기능을 NotificationService 인터페이스로 추상화
  - 구현 클래스 SlackNotificationService 구현